### PR TITLE
Make failure crate optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,8 @@ azure-devops = { project = "afnanenayet/hashed-permutation", pipeline = "afnanen
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-failure = "0.1"
+failure = { version = "0.1", optional = true }
+
+[features]
+default = []
+failure-crate = ["failure"]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
     displayName: 'Install rust'
   - script: rustc --version
     displayName: 'Rust version'
-  - script: cargo test
+  - script: cargo test --all-features
     displayName: 'Run tests'
 
 - job: macOS
@@ -32,7 +32,7 @@ jobs:
     displayName: 'Install rust'
   - script: rustc --version
     displayName: 'Rust version'
-  - script: cargo test
+  - script: cargo test --all-features
     displayName: 'Run tests'
 
 - job: Windows
@@ -46,7 +46,7 @@ jobs:
     displayName: 'Install rust'
   - script: rustc --version
     displayName: 'Rust version'
-  - script: cargo test
+  - script: cargo test --all-features
     displayName: 'Run tests'
 
 - job: Plumbing
@@ -55,7 +55,7 @@ jobs:
       displayName: 'Create Github release'
       inputs:
         githubConnection: afnanenayetgh
-        repositoryName: afnanenayet/oars
+        repositoryName: afnanenayet/hashed-permutation
         action: 'create'
         tagSource: auto
         compareWith: 'lastFullRelease'

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,34 @@
+#[cfg(failure)]
 use failure::Fail;
+use std::fmt::{self, Display};
 
-#[derive(Debug, Fail)]
+#[derive(Debug)]
+#[cfg_attr(feature = "failure", derive(Fail))]
 pub enum PermutationError {
-    #[fail(
-        display = "Attempted to shuffle {}, where the highest number is {}",
-        shuffle, max_shuffle
+    #[cfg_attr(
+        feature = "failure",
+        fail(
+            display = "Attempted to shuffle {}, where the highest number is {}",
+            shuffle, max_shuffle
+        )
     )]
     ShuffleOutOfRange { shuffle: u32, max_shuffle: u32 },
+}
+
+#[cfg(not(failure))]
+impl Display for PermutationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PermutationError::ShuffleOutOfRange {
+                shuffle,
+                max_shuffle: max,
+            } => write!(
+                f,
+                "Attempted to shuffle {}, where the highest number is {}",
+                shuffle, max
+            ),
+        }
+    }
 }
 
 /// A permutation result, which is simply an alias for any type that could return a permutation

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,14 @@
-#[cfg(failure)]
+#[cfg(feature = "failure-crate")]
 use failure::Fail;
+
+#[cfg(not(feature = "failure-crate"))]
 use std::fmt::{self, Display};
 
 #[derive(Debug)]
-#[cfg_attr(feature = "failure", derive(Fail))]
+#[cfg_attr(feature = "failure-crate", derive(Fail))]
 pub enum PermutationError {
     #[cfg_attr(
-        feature = "failure",
+        feature = "failure-crate",
         fail(
             display = "Attempted to shuffle {}, where the highest number is {}",
             shuffle, max_shuffle
@@ -15,7 +17,7 @@ pub enum PermutationError {
     ShuffleOutOfRange { shuffle: u32, max_shuffle: u32 },
 }
 
-#[cfg(not(failure))]
+#[cfg(not(feature = "failure-crate"))]
 impl Display for PermutationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,14 @@
 //! // Let's pick a randomly permuted number
 //! let permuted_number = perm.shuffle(0).unwrap();
 //! ```
+//!
+//! This library also provides optional support for the [failure](https://crates.io/crates/failure)
+//! crate. If you want to use `failure`, simply add the "failure-crate" dependency in your Cargo
+//! manifest.
+//!
+//! ```toml
+//! hashed-permutation = { version = "2.0.0", features = ["failure-crate"] }
+//! ```
 
 mod error;
 mod kensler;


### PR DESCRIPTION
Add optional support for the failure crate via features and cfg macros, so this library can be more lightweight.