### PR TITLE
Remove failure, use thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,9 @@ azure-devops = { project = "afnanenayet/hashed-permutation", pipeline = "afnanen
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-failure = { version = "0.1", optional = true }
 rand = { version = "0.7", optional = true }
+thiserror = "1.0"
 
 [features]
 default = []
-failure-crate = ["failure"]
 use-rand = ["rand"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,57 +1,24 @@
-#[cfg(feature = "failure-crate")]
-use failure::Fail;
+use thiserror::Error;
 
-#[cfg(not(feature = "failure-crate"))]
-use std::fmt::{self, Display};
-
-#[derive(Debug)]
-#[cfg_attr(feature = "failure-crate", derive(Fail))]
-// We allow the name repitition because this struct will not make sense outside of the crate
+/// The different types of errors that can arise from this crate
+#[derive(Debug, Error)]
+// We allow the name repetition because this struct will not make sense outside of the crate
 // otherwise, and this is exported as part of the library.
 #[allow(clippy::module_name_repetitions)]
 pub enum PermutationError {
-    #[cfg_attr(
-        feature = "failure-crate",
-        fail(
-            display = "Attempted to shuffle {}, where the highest number is {}",
-            shuffle, max_shuffle
-        )
-    )]
     /// This error is invoked when the caller attempts to use an index on the `shuffle` method that
     /// is larger than the size of the set.
     ///
     /// The user can only shuffle indices that are within the set, otherwise the hashing algorithm
     /// does not work. `shuffle` is the index that the user called, and `max_shuffle` is the size
     /// of the permutation set (which is also the upper bound for the calling index).
+    #[error("Attempted to shuffle index {shuffle}, but the length of the array is {max_shuffle}")]
     ShuffleOutOfRange { shuffle: u32, max_shuffle: u32 },
 
-    #[cfg_attr(
-        feature = "failure-crate",
-        fail(display = "Attempted to create a permutation struct with a length less than 1")
-    )]
-    /// This error represents the case where a permutation struct is created with a length that is
-    /// too small (0).
-    LengthTooSmall {},
-}
-
-#[cfg(not(feature = "failure-crate"))]
-impl Display for PermutationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            PermutationError::ShuffleOutOfRange {
-                shuffle,
-                max_shuffle: max,
-            } => write!(
-                f,
-                "Attempted to shuffle {}, where the highest number is {}",
-                shuffle, max
-            ),
-            PermutationError::LengthTooSmall {} => write!(
-                f,
-                "Attempted to create a permutation struct with a length less than 1"
-            ),
-        }
-    }
+    /// An construction error for when a hashed permutation instance is initialized with a length
+    /// of 0
+    #[error("The supplied length was too small")]
+    LengthTooSmall,
 }
 
 /// A permutation result, which is simply an alias for any type that could return a permutation


### PR DESCRIPTION
* Remove all instances of the deprecated `failure` crate
* Use `thiserror` to derive errors
* Remove `failure-crate` feature