### PR TITLE
feat: Add library example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ harness = false
 debug = 2
 lto = "thin"
 codegen-units = 1
+
+[[example]]
+name = "basic"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,22 @@
+use std::num::NonZeroU32;
+
+use hashed_permutation::HashedPermutation;
+
+fn main() {
+    let length = 2 << 22;
+    let perm = HashedPermutation {
+        seed: 1234,
+        length: NonZeroU32::new(length).unwrap(),
+    };
+
+    for i in 0..length {
+        match perm.shuffle(i) {
+            Ok(n) => {
+                println!("Index {i} -> {n}");
+            }
+            Err(e) => {
+                eprintln!("Got error {e} for index {i}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a basic library example so users can clone this repo and easily run an example executable showing how to use this library.
